### PR TITLE
Standardized locale names

### DIFF
--- a/locale/cs_CZ/locale.xml
+++ b/locale/cs_CZ/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="cs_CZ" full_name="Czech">
+<locale name="cs_CZ" full_name="Čeština">
 	<message key="plugins.generic.staticPages.displayName">Plugin statických stránek</message>
 	<message key="plugins.generic.staticPages.description">Tento plugin umožňuje správu statického obsahu.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Název</message>

--- a/locale/da_DK/locale.xml
+++ b/locale/da_DK/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
  
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.generic.staticPages.displayName">Statisk sideplugin</message>
 	<message key="plugins.generic.staticPages.description">Dette plugin tillader håndtering af statisk indhold</message>
 	<message key="plugins.generic.staticPages.pageTitle">Titel</message>

--- a/locale/el_GR/locale.xml
+++ b/locale/el_GR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="plugins.generic.staticPages.displayName">Plugin Στατικών Σελίδων</message>
 	<message key="plugins.generic.staticPages.description">Αυτό το plugin επιτρέπει την δημιουργία και διαχείριση στατικών σελίδων.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Τίτλος</message>

--- a/locale/es_ES/locale.xml
+++ b/locale/es_ES/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the es_ES (Spain Spanish) locale.
+  * Localization strings for the es_ES (Español (España)) locale.
   *
   -->
  

--- a/locale/fa_IR/locale.xml
+++ b/locale/fa_IR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="fa_IR" full_name="Persian">
+<locale name="fa_IR" full_name="فارسی">
 	<message key="plugins.generic.staticPages.displayName">پلاگین صفحات استاتیک</message>
 	<message key="plugins.generic.staticPages.description">با این پلاگین میتوان محتوای استاتیک را اداره کرد</message>
 	<message key="plugins.generic.staticPages.pageTitle">عنوان</message>

--- a/locale/id_ID/locale.xml
+++ b/locale/id_ID/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   *
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.generic.staticPages.displayName">Plugin Halaman Statis</message>
 	<message key="plugins.generic.staticPages.description">Plugin ini memudahkan Manajemen Konten Statis.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Judul</message>

--- a/locale/it_IT/locale.xml
+++ b/locale/it_IT/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="it_IT" full_name="Italian">
+<locale name="it_IT" full_name="Italiano">
 	<message key="plugins.generic.staticPages.displayName">Pagine statiche</message>
 	<message key="plugins.generic.staticPages.description">Questo plugin permette la creazione e la gestione di pagine statiche.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Titolo</message>

--- a/locale/nb_NO/locale.xml
+++ b/locale/nb_NO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
  
-<locale name="nb_NO" full_name="Norwegian">
+<locale name="nb_NO" full_name="Norsk bokmål">
 	<message key="plugins.generic.staticPages.displayName">Programutvidelse for statiske sider</message>
 	<message key="plugins.generic.staticPages.description">Denne programutvidselsen lar deg administrere statiske sider.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Tittel</message>

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.staticPages.displayName">Plugin de Páginas Estáticas</message>
 	<message key="plugins.generic.staticPages.description">Este plugin permite gerir páginas estáticas</message>
 	<message key="plugins.generic.staticPages.pageTitle">Título</message>

--- a/locale/ro_RO/locale.xml
+++ b/locale/ro_RO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   *
   -->
  
-<locale name="ro_RO" full_name="Română">
+<locale name="ro_RO" full_name="Limba Română">
 	<message key="plugins.generic.staticPages.displayName">Modul pentru pagini statice</message>
 	<message key="plugins.generic.staticPages.description">Acest modul permite managementul paginilor statice.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Titlu</message>

--- a/locale/sr_SR/locale.xml
+++ b/locale/sr_SR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
  
-<locale name="sr_SR" full_name="Serbian">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.generic.staticPages.displayName">Dodatak Statičke strane</message>
 	<message key="plugins.generic.staticPages.description">Ovaj dodatak omogućuje uređivanje statičkog sadržaja.</message>
 	<message key="plugins.generic.staticPages.pageTitle">Naslov</message>

--- a/locale/tr_TR/locale.xml
+++ b/locale/tr_TR/locale.xml
@@ -8,7 +8,7 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Turkish) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
  

--- a/locale/uk_UA/locale.xml
+++ b/locale/uk_UA/locale.xml
@@ -8,13 +8,13 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
        <message key="plugins.generic.staticPages.displayName">Модуль статичних сторінок</message>
        <message key="plugins.generic.staticPages.description">Цей модуль дозволяє керування статичним змістом.</message>
        <message key="plugins.generic.staticPages.pageTitle">Назва</message>

--- a/locale/zh_CN/locale.xml
+++ b/locale/zh_CN/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   *
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.generic.staticPages.displayName">静态页面插件(Static Pages Plugin)</message>
 	<message key="plugins.generic.staticPages.description">该插件允许管理静态内容(This plugin allows Static Content Management.)</message>
 	<message key="plugins.generic.staticPages.pageTitle">标题</message>


### PR DESCRIPTION
Following the recent standardization of locale names in the PKP applications, this tackles the staticPages plugin.
