### PR TITLE
pkp/staticPages#19: cleanup grid controllers a bit

### DIFF
--- a/controllers/grid/StaticPageGridCellProvider.inc.php
+++ b/controllers/grid/StaticPageGridCellProvider.inc.php
@@ -17,13 +17,6 @@ import('lib.pkp.classes.controllers.grid.GridCellProvider');
 import('lib.pkp.classes.linkAction.request.RedirectAction');
 
 class StaticPageGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
 
 	//
 	// Template methods from GridCellProvider
@@ -32,6 +25,7 @@ class StaticPageGridCellProvider extends GridCellProvider {
 	 * Get cell actions associated with this row/column combination
 	 * @param $row GridRow
 	 * @param $column GridColumn
+	 * @param $position int GRID_ACTION_POSITION_...
 	 * @return array an array of LinkAction instances
 	 */
 	function getCellActions($request, $row, $column, $position = GRID_ACTION_POSITION_DEFAULT) {

--- a/controllers/grid/StaticPageGridHandler.inc.php
+++ b/controllers/grid/StaticPageGridHandler.inc.php
@@ -45,7 +45,7 @@ class StaticPageGridHandler extends GridHandler {
 	// Overridden template methods
 	//
 	/**
-	 * @copydoc Gridhandler::initialize()
+	 * @copydoc GridHandler::initialize()
 	 */
 	function initialize($request, $args = null) {
 		parent::initialize($request, $args);
@@ -97,7 +97,7 @@ class StaticPageGridHandler extends GridHandler {
 	// Overridden methods from GridHandler
 	//
 	/**
-	 * @copydoc Gridhandler::getRowInstance()
+	 * @copydoc GridHandler::getRowInstance()
 	 */
 	function getRowInstance() {
 		return new StaticPageGridRow();

--- a/controllers/grid/StaticPageGridRow.inc.php
+++ b/controllers/grid/StaticPageGridRow.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridRow');
 
 class StaticPageGridRow extends GridRow {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Overridden template methods


### PR DESCRIPTION
Remove useless constructors and cleanup documentation typos and omissions for the Grid Controllers.